### PR TITLE
Remove useless line in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Add repositories and classpath in build script:
 ```
 buildscript {
     repositories {
-        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 


### PR DESCRIPTION
Previously, README example included a useless buildscript repository line.
Since this was useless this was also misleading.

This commit removes it.