### PR TITLE
Remove useless dependency on build tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ repositories {
 }
 ```
 
-Set main class (one with `public static void main(String [] args)` method):
+Set compilation options:
 ```
-mainClassName = "my.package.Main"
-```
+teavmc {
+    // Required, specify class with `public static void main(String[] args)` method
 
-Optionally set compilation options:
-```
-teavmc { //Optional configuration block
+    mainClass = "my.package.Main"
+
+    //Optional configuration block
+
     /* Where to put final web app*/
     installDirectory "${project.buildDir}/teavm"
     /* Main javascript file name */
@@ -77,8 +78,6 @@ To run app, open `main.html` from `installDirectory`.
 
 Usage
 =====
-
-Sample is located [here](https://github.com/edibleday/teavm-gradle-plugin-sample). Check comments in `build.gradle` file.
 
 To compile javascript application, use `teavmc` task. By default output will be located in `build/teavm` directory.
 

--- a/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
+++ b/src/main/kotlin/com/edibleday/TeaVMPlugin.kt
@@ -29,10 +29,6 @@ class TeaVMPlugin : Plugin<Project> {
                 "plugin" to "java"
         ))
 
-        project.apply(mapOf(
-                "plugin" to "application"
-        ))
-
         project.configurations.create("teavmsources")
 
         project.dependencies.let {
@@ -48,7 +44,7 @@ class TeaVMPlugin : Plugin<Project> {
 
         project.task(mapOf(
                 Task.TASK_TYPE to TeaVMTask::class.java,
-                Task.TASK_DEPENDS_ON to "build",
+                Task.TASK_DEPENDS_ON to "classes",
                 Task.TASK_DESCRIPTION to "TeaVM Compile",
                 Task.TASK_GROUP to "build"
         ), "teavmc");


### PR DESCRIPTION
Previously, `teavmc` task declared a dependency on the `build` task of
the user project. This was useless because TeaVM only needs compiled
class files, it doesn't need jars or distribution archives.

This was very costly as these useless tasks represented about half
of the build time.

This commit removes this dependency on useless tasks, to double the
build speed.

## Note for reviewers

I haven't used TeaVM for long and I have never used Maven, so I am not 100% sure that this is correct.

Here is my analysis:

- [The Maven plugin's default phase is `process-classes`](https://github.com/konsoletyper/teavm/blob/master/tools/maven/plugin/src/main/java/org/teavm/maven/TeaVMCompileMojo.java#L57)
- According to [Maven docs](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#Lifecycle_Reference), this corresponds to right after compiling.
